### PR TITLE
Improve support for using hab with a different python than default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ instead of the official releases. See the [test_resolve_paths](tests/test_site.p
 see an example of [overriding](tests/site_override.json) the
 [main](tests/site_main.json) site settings.
 
+### Python version
+
+Habitat uses shell script files instead of an entry_point executable. This allows it
+to modify the existing shell(see `hab activate`). This has a small drawback of needing
+to know what version of python to call. It relies on the assumption that you are using
+hab with the default python 3 install. For example that you can call `python3 -m hab`
+or `py -3 -m hab` on windows. Here is a breakdown of how the python call is built by
+the scripts:
+
+1. If the `HAB_PYTHON` env var is set, its value is always used.
+2. If a virtualenv is active, the `python` command is used.
+3. Otherwise on linux `python3` is used, and on windows `py -3` is used.
 
 #### Common settings
 

--- a/bin/hab
+++ b/bin/hab
@@ -15,8 +15,28 @@ rm -f $temp_launch_file $temp_config_file
 # Ensure the tempfiles are remove on exit if they were created
 trap "rm -f $temp_launch_file $temp_config_file" EXIT
 
+# Calculate the command to run python with
+if [[ ! -z "${HAB_PYTHON}" ]]; then
+    # If HAB_PYTHON is specified, use it explicitly
+    py_exe="${HAB_PYTHON}"
+elif [[ -z "${VIRTUAL_ENV}" ]]; then
+    # Otherwise if we are not in a virtualenv use system defined generic
+    # python call for the given os if not inside a virtualenv
+    unameOut="$(uname -s)"
+    case "${unameOut}" in
+        Linux*)     py_exe=python3;;
+        Darwin*)    py_exe=python3;;
+        # Assume other os's are windows
+        *)          py_exe="py -3"
+    esac
+else
+    # We are inside a virtualenv, so just use the python command
+    py_exe="python"
+fi
+echo "$py_exe"
+
 # Call our worker python process that may write the temp filename
-python -m habitat --file-config $temp_config_file --file-launch $temp_launch_file "$@"
+$py_exe -m habitat --file-config $temp_config_file --file-launch $temp_launch_file "$@"
 
 # Run the launch or config script if it was created on disk
 if test -f "$temp_launch_file"; then

--- a/bin/hab.bat
+++ b/bin/hab.bat
@@ -14,8 +14,22 @@ if exist "%temp_config_file%_config.bat" goto :uniqLoop
 set "temp_launch_file=%temp_config_file%_launch.bat"
 set "temp_config_file=%temp_config_file%_config.bat"
 
+:: Calculate the command to run python with
+SETLOCAL ENABLEEXTENSIONS
+IF DEFINED HAB_PYTHON (
+    :: If HAB_PYTHON is specified, use it explicitly
+    set py_exe=%HAB_PYTHON%
+) ELSE IF DEFINED VIRTUAL_ENV (
+    :: We are inside a virtualenv, so just use the python command
+    set py_exe=python
+) ELSE (
+    :: Use system defined generic python call
+    set "py_exe=py -3"
+)
+
 :: Call our worker python process that may write the temp filename
-python -m habitat --file-config "%temp_config_file%" --file-launch "%temp_launch_file%" %*
+%py_exe% -m habitat --file-config "%temp_config_file%" --file-launch "%temp_launch_file%" %*
+ENDLOCAL
 
 :: Run the launch or config script if it was created on disk
 if exist %temp_launch_file% (

--- a/bin/hab.ps1
+++ b/bin/hab.ps1
@@ -15,8 +15,22 @@ Remove-Item $temp_launch
 $temp_config=[System.IO.Path]::ChangeExtension($temp_config, "ps1")
 $temp_launch=[System.IO.Path]::ChangeExtension($temp_launch, "ps1")
 
+# Calculate the command to run python with
+if ($env:HAB_PYTHON -ne $null) {
+    # If HAB_PYTHON is specified, use it explicitly
+    $py_exe = $env:HAB_PYTHON
+}
+elseif ($env:VIRTUAL_ENV -ne $null) {
+    # We are inside a virtualenv, so just use the python command
+    $py_exe = "python"
+}
+else {
+    # Use system defined generic python call
+    $py_exe = "py -3"
+}
+
 # Call our worker python process that may write the temp filename
-python -m habitat --file-config $temp_config --file-launch $temp_launch $args
+Invoke-Expression "$py_exe -m habitat --file-config $temp_config --file-launch $temp_launch $args"
 
 # Run the launch or config script if it was created on disk
 if (Test-Path $temp_launch -PathType Leaf)


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

Fix an issue if `python` maps to python 2 hab breaks. Add ability to specify the python being executed.

1. If the `HAB_PYTHON` env var is set, its value is always used.
2. If a virtualenv is active, the `python` command is used.
3. Otherwise on linux `python3` is used, and on windows `py -3` is used.